### PR TITLE
Some Opinionated Changes + Resize Implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use softbuffer::Surface;
 use winit::application::ApplicationHandler;
+use winit::dpi::PhysicalSize;
 use winit::error::EventLoopError;
 use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
@@ -10,17 +11,15 @@ use winit::window::{Window, WindowId};
 
 /// Contains a few potential properties to set for a SoftbufferWindow when it is created.
 pub struct WindowProperties {
-    width: u32,
-    height: u32,
-    title: String,
+    pub size: PhysicalSize<u32>,
+    pub title: Box<str>,
 }
 
-impl std::default::Default for WindowProperties {
+impl Default for WindowProperties {
     fn default() -> WindowProperties {
         WindowProperties {
-            width: 800,
-            height: 600,
-            title: String::from("Softbuffer window"),
+            size: PhysicalSize::new(800, 600),
+            title: "Softbuffer window".into(),
         }
     }
 }
@@ -28,16 +27,9 @@ impl std::default::Default for WindowProperties {
 impl WindowProperties {
     pub fn new(width: u32, height: u32, title: &str) -> WindowProperties {
         WindowProperties {
-            width,
-            height,
-            title: String::from(title),
+            size: PhysicalSize::new(width, height),
+            title: title.into(),
         }
-    }
-    pub fn get_size(&self) -> (u32, u32) {
-        (self.width, self.height)
-    }
-    pub fn get_title(&self) -> &str {
-        self.title.as_str()
     }
 }
 
@@ -60,17 +52,14 @@ where
         let window = {
             let window = event_loop.create_window(
                 Window::default_attributes()
-                    .with_title(self.properties.get_title())
-                    .with_inner_size(winit::dpi::LogicalSize::new(
-                        self.properties.get_size().0,
-                        self.properties.get_size().1,
-                    )),
+                    .with_title(self.properties.title.clone())
+                    .with_inner_size(self.properties.size),
             );
             Rc::new(window.unwrap())
         };
         let context = softbuffer::Context::new(window.clone()).unwrap();
         self.window = Some(window.clone());
-        self.surface = Some(softbuffer::Surface::new(&context, window.clone()).unwrap());
+        self.surface = Some(Surface::new(&context, window.clone()).unwrap());
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
@@ -78,26 +67,22 @@ where
             WindowEvent::CloseRequested => {
                 event_loop.exit();
             }
-            WindowEvent::RedrawRequested => {
-                let window = self.window.clone().unwrap();
-                let surface = self.surface.as_mut().unwrap();
-                let (width, height) = {
-                    let size = window.inner_size();
-                    (size.width, size.height)
-                };
-                surface
+            WindowEvent::Resized(new_size) => {
+                self.properties.size = new_size;
+                let (width, height) = (new_size.width, new_size.height);
+                self.surface
+                    .as_mut()
+                    .unwrap()
                     .resize(
                         NonZeroU32::new(width).unwrap(),
                         NonZeroU32::new(height).unwrap(),
                     )
                     .unwrap();
-
-                let mut buffer = surface.buffer_mut().unwrap();
-
-                (self.loop_fn)(window, buffer.as_mut());
-
+            }
+            WindowEvent::RedrawRequested => {
+                let mut buffer = self.surface.as_mut().unwrap().buffer_mut().unwrap();
+                (self.loop_fn)(self.window.clone().unwrap(), buffer.as_mut());
                 buffer.present().unwrap();
-
                 self.window.as_ref().unwrap().request_redraw();
             }
             _ => (),


### PR DESCRIPTION
Changes:
- title can be a boxed `str`
- use `winit::dpi::PhysicalSize<u32>` instead of two fields for brevity and consistency

Suggestion:
- instead of the window handle in the `loop_fn`, maybe a customized `Context` maybe better